### PR TITLE
[INVE-11178] ES7 mapping types legacy support

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -408,7 +408,8 @@ class elasticsearch {
           }
 
           async.eachSeries(sortedMappings, (set, done) => {
-            let __type = ''
+            // kibi: INVE-11178, added 'doc' to PUT mapping url
+            let __type = '/doc'
             if (this.ESversion < 7) {
               __type = `/${encodeURIComponent(set.key)}`
             } else if (set.key !== 'properties') {
@@ -423,7 +424,8 @@ class elasticsearch {
               __type = `/${set.index}${__type}`
             }
 
-            const url = `${this.base.url}${__type}/_mapping`
+            // kibi: INVE-11178, include_type_name for legacy ES doc types
+            const url = `${this.base.url}${__type}/_mapping?include_type_name`
             const payload = {
               url,
               method: 'PUT',


### PR DESCRIPTION
### Description

Added `include_type_name` support for the PUT mapping API, required to restore `doc` types currently used by Investigate

### How to Test / Manual Testing

Fotographic proof it works:

![elasticdump_es7_backup_test](https://user-images.githubusercontent.com/16387428/80799158-a43bec80-8b95-11ea-8ceb-4523de22710f.gif)

### Unit Tests

I tried to run the unit tests for ElasticDump, and I didn't see any _additional_ errors. There were the same errors in the `master` branch too, about unrelated stuff (parent/child docs and templates).

Normal import/export especially from/to file works so I'm content.
