### PR TITLE
[INVE-11966] Add include_type_name only if the Elasticsearch version is >= 6.8.0

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -23,7 +23,12 @@ class elasticsearch {
     this.totalSearchResults = 0
     this.elementsToSkip = 0
     this.searchBody = this.parent.options.searchBody
+
+    // kibi: major version as a number
     this.ESversion = null
+
+    // kibi: minor version as a number
+    this.ESversionMinor = null
 
     const defaultOptions = {
       timeout: this.parent.options.timeout,
@@ -119,8 +124,12 @@ class elasticsearch {
       response = jsonParser.parse(response.body)
 
       if (response.version) {
-        this.ESversion = response.version.number.split('.')[0]
-        this.parent.emit('debug', `discovered elasticsearch ${prefix} major version: ${this.ESversion}`)
+        // kibi: retrieve minor version number
+        const parts = response.version.number.split('.')
+        this.ESversion = parseInt(parts[0])
+        this.ESversionMinor = parseInt(parts[1])
+
+        this.parent.emit('info', `discovered elasticsearch ${prefix} major version: ${this.ESversion}`)
       } else {
         this.ESversion = 5
         this.parent.emit('debug', `cannot discover elasticsearch ${prefix} major version, assuming: ${this.ESversion}`)
@@ -425,7 +434,12 @@ class elasticsearch {
             }
 
             // kibi: INVE-11178, include_type_name for legacy ES doc types
-            const url = `${this.base.url}${__type}/_mapping?include_type_name`
+            // kibi: INVE-11966 if ES version is greater than 6.8.0
+            let querystring = ''
+            if (this.ESversion === 7 || (this.ESversion === 6 && this.ESversionMinor >= 8)) {
+              querystring = '?include_type_name'
+            }
+            const url = `${this.base.url}${__type}/_mapping${querystring}`
             const payload = {
               url,
               method: 'PUT',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Evan Tahler <evantahler@gmail.com>",
   "name": "elasticdump",
   "description": "import and export tools for elasticsearch",
-  "version": "6.28.0",
+  "version": "6.28.0-siren-2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See Jira issue for tests .