### PR TITLE
[INVE-11862] - Catch errors on invalid JSON in stream

### DIFF
--- a/lib/transports/base.js
+++ b/lib/transports/base.js
@@ -34,6 +34,10 @@ class base {
 
     if (this.lineCounter === 0) {
       this.setupGet(offset)
+        .catch(e => {
+          this.completeBatch(e, this.thisGetCallback, false)
+        })
+      return
     } else {
       this._resume()
     }
@@ -43,7 +47,7 @@ class base {
     }
   }
 
-  setupGet (offset) {
+  async setupGet (offset) {
     throw new Error('Not Yet Implementation')
   }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Evan Tahler <evantahler@gmail.com>",
   "name": "elasticdump",
   "description": "import and export tools for elasticsearch",
-  "version": "6.28.0-siren-2",
+  "version": "6.28.0-siren-3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
If the setup of a file stream fails because of invalid JSON content, elasticdump will get stuck and not report the error.