### PR TITLE
[INVE-12574] No error when credentials invalid

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -121,6 +121,10 @@ class elasticsearch {
     aws4signer(esRequest, this.parent)
     this.baseRequest(esRequest, (err, response) => {
       if (err) { return callback(err) }
+      if (response.statusCode !== 200) {
+        const errMsg = `An error occurred: [${response.statusCode}] ${response.body}`
+        return callback(errMsg)
+      }
       response = jsonParser.parse(response.body)
 
       if (response.version) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Evan Tahler <evantahler@gmail.com>",
   "name": "elasticdump",
   "description": "import and export tools for elasticsearch",
-  "version": "6.28.0-siren-3",
+  "version": "6.28.0-siren-4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[INVE-12574] BugFix: When credentials are invalid, bin/investigate backup does not report errors.

## Next Steps (After merge):

- [x] Tag a new release `tag-6.28.0-siren-4`.
- [x] Open a PR in [kibi-internal](https://github.com/sirensolutions/kibi-internal) to bump elasticdump dependency.


[INVE-12574]: https://sirensolutions.atlassian.net/browse/INVE-12574